### PR TITLE
Add google.co.jp as a Google domain

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
 
     "content_scripts": [
 	{
-	    "matches": ["*://www.google.com/search?*", "*://www.google.ca/search?*", "*://www.google.co.uk/search?*", "*://www.google.se/search?*", "*://www.google.de/search?*"],
+	    "matches": ["*://www.google.com/search?*", "*://www.google.ca/search?*", "*://www.google.co.uk/search?*", "*://www.google.se/search?*", "*://www.google.de/search?*", "*://www.google.co.jp/search?*"],
 	    "js": ["linkfix.js"]
 	}
     ]


### PR DESCRIPTION
(On a semi-related question: Wouldn't it be nicer to acquire a [list of google domains](https://ipfs.io/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/List_of_Google_domains.html), and just throw them all in?)